### PR TITLE
systemd: use sudo for non-interactive stop/start

### DIFF
--- a/home/nodo/common.sh
+++ b/home/nodo/common.sh
@@ -183,14 +183,14 @@ log() {
 services="monerod monero-lws monero-wallet-rpc moneropay"
 services-stop() {
 	for f in $services; do
-		systemctl stop "$f".service
+		sudo systemctl stop "$f".service
 	done
 }
 
 services-start() {
 	for f in $services; do
 		if systemctl is-enabled "$f".service; then
-			systemctl start "$f".service
+			sudo systemctl start "$f".service
 		fi
 	done
 }


### PR DESCRIPTION
```
Failed to stop monerod.service: Interactive authentication required.
See system logs and 'systemctl status monerod.service' for details.
Failed to stop monero-lws.service: Interactive authentication required.
See system logs and 'systemctl status monero-lws.service' for details.
Failed to stop monero-wallet-rpc.service: Interactive authentication required.
See system logs and 'systemctl status monero-wallet-rpc.service' for details.
Failed to stop moneropay.service: Interactive authentication required.
See system logs and 'systemctl status moneropay.service' for details.
cp: cannot create regular file '/home/nodo/bin/monerod': Text file busy
```

services-stop fails (requires being run as sudo lr interactive authentication), causing
1. monerod not stopped, which causes the monerod binary to remain busy causing update to fail. Build completes, but the files cant be copied overtop of the old versions