### PR TITLE
banlist: ensure updates apply correctly

### DIFF
--- a/home/nodo/execScripts/monerod.sh
+++ b/home/nodo/execScripts/monerod.sh
@@ -59,7 +59,7 @@ if [ "$RPC_ENABLED" == "TRUE" ]; then
 fi
 
 if [ "$BANLIST_BOOG900_ENABLED" == "TRUE" ] || [ "$BANLIST_GUIXMRPM_ENABLED" == "TRUE" ]; then
-	[ -f /media/monero/banlist.txt ] || bash /home/nodo/update-banlists.sh
+	bash /home/nodo/update-banlists.sh
 	banlist_args="--ban-list /media/monero/banlist.txt "
 fi
 

--- a/update-banlists.sh
+++ b/update-banlists.sh
@@ -3,10 +3,33 @@
 . "$_cwd"/home/nodo/common.sh
 
 cd /media/monero/ || exit 1
-{
-	[ "$(getvar "banlists.boog900")" == "TRUE" ] && curl -LSs https://github.com/Boog900/monero-ban-list/raw/refs/heads/main/ban_list.txt
-	[ "$(getvar 'banlists."gui-xmr-pm"')" == "TRUE" ] && curl -LSs https://gui.xmr.pm/files/block.txt
-} | sort -u > newbanlist && cp newbanlist banlist.txt
 
+mrl_banlist=""
+xmrpm_banlist=""
+{
+	[ "$(getvar "banlists.boog900")" == "TRUE" ] && curl -LSs https://github.com/Boog900/monero-ban-list/raw/refs/heads/main/ban_list.txt || echo "MRL list failed to update"; mrl_banlist="mrl banlist"
+	[ "$(getvar 'banlists."gui-xmr-pm"')" == "TRUE" ] && curl -LSs https://gui.xmr.pm/files/block.txt || echo "xmr.pm banlist failed to update"; xmrpm_banlist="xmr.pm banlist"
+} | sort -u > newbanlist
+
+if [[ -z "${mrl_banlist}" ]] && [[ -z "${xmrpm_banlist}" ]]; then
+	if [[ $(cat newbanlist) == $(cat banlist.txt) ]]; then
+		echo "Banlist up-to-date"
+		exit 0
+	else
+		echo "Generating new banlist.txt"
+	fi
+else
+	if [[ -f banlist.txt ]]; then
+		if [[ $(cat banlist.txt) != "" ]]; then
+			echo "Using old banlist.txt instead"
+			exit 1
+		fi
+	elif [[ $(cat newbanlist) != "" ]]; then
+		echo "Using the ${xmrpm_banlist}${mrl_banlist}"
+	else
+		echo "Creating blank placeholder banlist.txt"
+	fi
+fi
+cp newbanlist banlist.txt
 chown monero:monero banlist.txt
 chmod 600 banlist.txt

--- a/update-monero.sh
+++ b/update-monero.sh
@@ -34,8 +34,6 @@ fi
 
 showtext "Building Monero..."
 
-[ -f /media/monero/banlist.txt ] || bash /home/nodo/update-banlists.sh
-
 {
 	test -d monero.new && rm -rf monero.new
 	tries=0

--- a/var/spool/cron/crontabs/root
+++ b/var/spool/cron/crontabs/root
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 */30 * * * * bash /home/nodo/update-all.sh
 0 1 * * * bash /home/nodo/update-banlists.sh
 #0 * * * * bash /home/nodo/execScripts/monero-wallet-rpc-sweep.sh

--- a/var/spool/cron/crontabs/root
+++ b/var/spool/cron/crontabs/root
@@ -1,3 +1,3 @@
 */30 * * * * bash /home/nodo/update-all.sh
-0 * * * * bash /home/nodo/execScripts/monero-wallet-rpc-sweep.sh
 0 1 * * * bash /home/nodo/update-banlists.sh
+#0 * * * * bash /home/nodo/execScripts/monero-wallet-rpc-sweep.sh


### PR DESCRIPTION
Fixes issue where banlist is frequently blank.

checks for updates when monerod service is started (same as dns-blocklist). No need to check when monerod is updated.

only overwrites if necessary.