### PR TITLE
locale: fix errors about locale being unset

### DIFF
--- a/setup-nodo.sh
+++ b/setup-nodo.sh
@@ -24,6 +24,12 @@ vm.nr_hugepages=3072
 vm.swappiness=10
 EOF
 
+##Set & gendrete default / at least one locale
+locale="en_US.UTF-8"
+if [[ $(grep "# ${locale}" /etc/locale.gen) ]]; then
+	sed -i "s/# ${locale}/${locale}/" /etc/locale.gen && locale-gen && update-locale
+fi
+
 ##Perform system update and upgrade now. This then allows for reboot before next install step, preventing warnings about kernal upgrades when installing the new packages (dependencies).
 #setup debug file to track errors
 showtext "Creating Debug log..."


### PR DESCRIPTION
Example:
```
AutoUic: Detected locale "C" with character encoding "ANSI_X3.4-1968", which is not UTF-8.
Qt depends on a UTF-8 locale, and has switched to "C.UTF-8" instead.                            
If this causes problems, reconfigure your locale. See the locale(1) manual for more information.
```