### PR TITLE
update: attempt update-nodo.sh fix

### DIFF
--- a/setup-nodo.sh
+++ b/setup-nodo.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cwd="$(pwd)"
+_cwd=/root/nodo
 test "$_cwd" = "" && exit 1
 
 . "$_cwd"/home/nodo/common.sh

--- a/update-all.sh
+++ b/update-all.sh
@@ -57,15 +57,15 @@ if [ "$(getvar tor_global_enabled)" = "TRUE" ]; then
 fi
 export ALL_PROXY
 
-bash /home/nodo/update-nodo.sh
+bash /root/nodo/update-nodo.sh
 cd /home/nodo || exit 1
 chown nodo:nodo -R nodoui monero monero-lws
 mkdir -p /home/nodo/bin
 chown nodo:nodo /home/nodo/bin
-sudo --preserve-env=ALL_PROXY -u nodo bash /home/nodo/update-pay.sh
-sudo --preserve-env=ALL_PROXY -u nodo bash /home/nodo/update-monero.sh && \
-sudo --preserve-env=ALL_PROXY -u nodo bash /home/nodo/update-monero-lws.sh # LWS depends on Monero codebas
-bash /home/nodo/update-nodoui.sh
+sudo --preserve-env=ALL_PROXY -u nodo bash /root/nodo/update-pay.sh
+sudo --preserve-env=ALL_PROXY -u nodo bash /root/nodo/update-monero.sh && \
+sudo --preserve-env=ALL_PROXY -u nodo bash /root/nodo/update-monero-lws.sh # LWS depends on Monero codebas
+bash /root/nodo/update-nodoui.sh
 
 # Ensure i2p and tor are properly configured.
 expectedi2p=$(getvar 'i2p_address')

--- a/update-nodo.sh
+++ b/update-nodo.sh
@@ -86,4 +86,4 @@ showtext "User configuration restored"
 	putvar "versions.names.nodo" "$_NAME"
 	#ubuntu /dev/null odd requiremnt to set permissions
 	chmod 777 /dev/null
-} 2>&1 | tee -a "$DEBUG_LOG"
+} 2>&1 | tee -a "$DEBUG_LOG";

--- a/var/spool/cron/crontabs/root
+++ b/var/spool/cron/crontabs/root
@@ -1,4 +1,4 @@
 SHELL=/bin/bash
-*/30 * * * * bash /home/nodo/update-all.sh
-0 1 * * * bash /home/nodo/update-banlists.sh
+*/30 * * * * bash /root/nodo/update-all.sh
+0 1 * * * bash /root/nodo/update-banlists.sh
 #0 * * * * bash /home/nodo/execScripts/monero-wallet-rpc-sweep.sh


### PR DESCRIPTION
### commit 1:
1. update-all calls update-nodo
2. once update-nodo finishes, it falls back into update-all
3. from here, update-all tries to cd /home/nodo, but fails * and hits exit 1
4. as a result, the remaining update-* scripts are not run

* the fail i'm seeing is:
```
update-all.sh: line 61: d: command not found
```

so it seems the update-nodo script isnt ending cleanly. 
adding `;` seems to work .. 🤷‍♂️


### commit 2:
```
Building Monero...
fatal: destination path 'monero.new' already exists and is not an empty directory.
```
And
```
[100%] Built target monero-lws-daemon
cp: cannot create regular file '/home/nodo/bin/monero-lws-daemon': Text file busy
```
tell me that, even though /root/nodo _is_ updated, it is failing to copy the files over to /home/nodo/ (where they are run from).

The attempted fix here is to assume the copy is failing due to an incorrectly set _cwd variable. 
an alternative fix would be to 

### commit 3:
run the scripts directly from /root/nodo 