### PR TITLE
setup: use full-upgrade instead of dist-upgrade

### DIFF
--- a/setup-nodo.sh
+++ b/setup-nodo.sh
@@ -62,10 +62,11 @@ echo "force-confnew" >/etc/dpkg/dpkg.cfg.d/force-confnew
 showtext "Downloading and installing OS updates..."
 {
 	apt update
-	eval "$_APTGET" dist-upgrade
+	#eval "$_APTGET" dist-upgrade
+	eval "$_APTGET" full-upgrade
 	eval "$_APTGET" upgrade
 	##Auto remove any obsolete packages
-	eval "$_APTGET" apt autoremove
+	eval "$_APTGET" autoremove
 } 2>&1 | tee -a "$DEBUG_LOG"
 
 ##Installing dependencies for --- Web Interface

--- a/setup-nodo.sh
+++ b/setup-nodo.sh
@@ -114,7 +114,7 @@ showtext "Configuring apache server for access to Monero log file..."
 		chmod 644 /etc/tor/torrc
 		chown root /etc/tor/torrc
 		showtext "Restarting tor service..."
-		service tor restart
+		systemctl restart tor
 	fi
 } 2>&1 | tee -a "$DEBUG_LOG"
 


### PR DESCRIPTION
dist-upgrade is more lilely to cause breakages by removing files when it has a conflict (usually caused by a partially updated mirror)

removed extra `apt`