### PR TITLE
setup: disable usermod for webui

### DIFF
--- a/setup-nodo.sh
+++ b/setup-nodo.sh
@@ -69,8 +69,8 @@ showtext "Downloading and installing OS updates..."
 } 2>&1 | tee -a "$DEBUG_LOG"
 
 ##Installing dependencies for --- Web Interface
-showtext "Installing dependencies for Web Interface..."
-usermod -a -G nodo www-data
+#showtext "Installing dependencies for Web Interface..."
+#usermod -a -G nodo www-data
 
 showtext "Install home contents"
 cp -vr "$_cwd"/home/nodo/* /home/nodo/


### PR DESCRIPTION
somehow interfering

```
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.                          
Installing dependencies for Web Interface...                                            
FALL THROUGH #####################                                                      Merge config.json
```

it skips the rest of the setup-nodo

after pr
```
Installing dependencies for Web Interface...
Install home contents
'/root/nodo/home/nodo/bootStatusSetIdle.sh' -> '/home/nodo/bootStatusSetIdle.sh'
'/root/nodo/home/nodo/check-disk.sh' -> '/home/nodo/check-disk.sh'
'/root/nodo/home/nodo/common.sh' -> '/home/nodo/common.sh'
'/root/nodo/home/nodo/cpuTemp.sh' -> '/home/nodo/cpuTemp.sh'
'/root/nodo/home/nodo/df-h.sh' -> '/home/nodo/df-h.sh'
'/root/nodo/home/nodo/execScripts/monero-lws.sh' -> '/home/nodo/execScripts/monero-lws.sh'

....

FALL THROUGH #####################            
```