### PR TITLE
cron: add PATH

### DIFF
--- a/setup-nodo.sh
+++ b/setup-nodo.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 _cwd=/root/nodo
 test "$_cwd" = "" && exit 1
 

--- a/var/spool/cron/crontabs/root
+++ b/var/spool/cron/crontabs/root
@@ -1,4 +1,5 @@
 SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 */30 * * * * bash /root/nodo/update-all.sh
 0 1 * * * bash /root/nodo/update-banlists.sh
 #0 * * * * bash /home/nodo/execScripts/monero-wallet-rpc-sweep.sh


### PR DESCRIPTION
Fixes issue where some commands are unable to be found (like sysctl), causing the script to exit prematurely

~~Added $PATH to setup-nodo temporarily, to ensure the script succeeds~~ <- Not necessary. Removing set -e will allow the script to proceed through errors