### PR TITLE
update: universal update func + fix spam rebuilds

### DIFF
--- a/home/nodo/common.sh
+++ b/home/nodo/common.sh
@@ -111,6 +111,38 @@ check_connection() {
 	return 1
 }
 
+check_update_tag() {
+	tries=0
+	maxtries=3
+	while [ -z "$RELEASE" ] || [ "$RELEASE" == "null" ]; do
+		if [ "${tries}" -ge "${maxtries}" ]; then
+			showtext "[${tries}/${maxtries}] Update check failed for $2"
+			exit 0
+		fi
+
+		# Check for updates
+		tries=$((tries+1))
+		showtext "[${tries}/${maxtries}] Checking updates for $2"
+		if [ "$2" == "Monero" ]; then  # strictly use releases for monero
+			RELNAME=$(get_release_commit_name "$1" "$2")
+		elif [ "$3" == "github.com" ]; then
+			RELNAME=$(get_tag_commit_name "$1" "$2")
+		elif [ "$3" == "gitlab.com" ]; then
+			RELNAME=$(gitlab_get_tag_commit_name "$1" "$2")
+		fi
+		RELEASE=$(printf '%s' "$RELNAME" | head -n1)
+		_NAME=$(printf '%s' "$RELNAME" | tail -n1)
+		echo "${RELEASE}"
+		echo "${_NAME}"
+		sleep 2
+	done
+
+	if [[ "$OLD_VERSION" == "$RELEASE" ]]; then
+		showtext "No update for $2"
+		exit 0
+	fi
+}
+
 ENCRYPT_FS="0"
 
 setup_drive() {

--- a/home/nodo/common.sh
+++ b/home/nodo/common.sh
@@ -116,7 +116,7 @@ check_update_tag() {
 	maxtries=3
 	while [ -z "$RELEASE" ] || [ "$RELEASE" == "null" ]; do
 		if [ "${tries}" -ge "${maxtries}" ]; then
-			showtext "[${tries}/${maxtries}] Update check failed for $2"
+			showtext "[${tries}/${maxtries}] Update check failed for $2\n"
 			exit 0
 		fi
 
@@ -132,13 +132,14 @@ check_update_tag() {
 		fi
 		RELEASE=$(printf '%s' "$RELNAME" | head -n1)
 		_NAME=$(printf '%s' "$RELNAME" | tail -n1)
-		echo "${RELEASE}"
-		echo "${_NAME}"
 		sleep 2
 	done
 
+	echo "${OLD_TAG} -> ${_NAME}"
+	echo "${RELEASE}"
+
 	if [[ "$OLD_VERSION" == "$RELEASE" ]]; then
-		showtext "No update for $2"
+		showtext "No update for $2\n"
 		exit 0
 	fi
 }

--- a/home/nodo/common.sh
+++ b/home/nodo/common.sh
@@ -123,12 +123,24 @@ check_update_tag() {
 		# Check for updates
 		tries=$((tries+1))
 		showtext "[${tries}/${maxtries}] Checking updates for $2"
-		if [ "$2" == "Monero" ]; then  # strictly use releases for monero
-			RELNAME=$(get_release_commit_name "$1" "$2")
-		elif [ "$3" == "github.com" ]; then
-			RELNAME=$(get_tag_commit_name "$1" "$2")
+		if [ "$3" == "github.com" ]; then
+			if [ "$4" == "release" ]; then
+				RELNAME=$(get_release_commit_name "$1" "$2")
+			elif [ "$4" == "tag" ]; then
+				RELNAME=$(get_tag_commit_name "$1" "$2")
+			else
+				echo -e "Error: Invalid release type for $2\n"
+				exit 1
+			fi
 		elif [ "$3" == "gitlab.com" ]; then
-			RELNAME=$(gitlab_get_tag_commit_name "$1" "$2")
+			if [ "$4" == "release" ]; then
+				RELNAME=$(gitlab_get_release_commit_name "$1" "$2" "$3")
+			elif [ "$4" == "tag" ]; then
+				RELNAME=$(gitlab_get_tag_commit_name "$1" "$2" "$3")
+			else
+				echo -e "Error: Invalid release type for $2\n"
+				exit 1
+			fi
 		fi
 		RELEASE=$(printf '%s' "$RELNAME" | head -n1)
 		_NAME=$(printf '%s' "$RELNAME" | tail -n1)

--- a/update-monero-lws.sh
+++ b/update-monero-lws.sh
@@ -10,11 +10,18 @@ fi
 #(1) Define variables and updater functions
 #shellcheck source=home/nodo/common.sh
 . /home/nodo/common.sh
-OLD_VERSION_LWS="${1:-$(getvar "versions.lws")}"
 
-RELNAME="d8ee984b3c43babbefbb405ae7ebf75b57e85b0c"
+cd /home/nodo || exit 1
+
+OLD_VERSION_LWS="${1:-$(getvar "versions.lws")}"
+#Error Log:
+touch "$DEBUG_LOG"
+
+#RELNAME=$(get_release_commit_name "vtnerd" "monero-lws")
+#RELEASE="$(printf '%s' "$RELNAME" | head -n1)"
+RELNAME="d8ee984b3c43babbefbb405ae7ebf75b57e85b0c"  # Temporary band-aid as newer commits don't seem to want to build
 RELEASE="$(printf '%s' "$RELNAME" | head -n1)"
-_NAME="$(printf '%s' "$RELNAME" | tail -n1)"
+_NAME="${RELNAME:0:8}"
 
 if [ -z "$RELEASE" ] && [ -z "$FIRSTINSTALL" ]; then # Release somehow not set or empty
 	showtext "Failed to check for update for LWS"
@@ -26,30 +33,27 @@ if [ "$RELEASE" == "$OLD_VERSION_LWS" ]; then
 	exit 0
 fi
 
-touch "$DEBUG_LOG"
+showtext "Building VTNerd Monero-LWS.."
 
-##Delete old version
-showtext "Delete old version"
-showtext "Downloading VTNerd Monero-LWS"
 {
-	tries=0
-	if [ -d monero-lws ]; then
-		rm -rf /home/nodo/monero-lws
+	if [ ! -d monero-lws ]; then
+		tries=0
+		until git clone --recursive https://github.com/vtnerd/monero-lws.git; do
+			sleep 1
+			tries=$((tries + 1))
+			if [ $tries -ge 5 ]; then
+				exit 1
+			fi
+		done
 	fi
-	until git clone --recursive https://github.com/vtnerd/monero-lws.git; do
-		sleep 1
-		tries=$((tries + 1))
-		if [ $tries -ge 5 ]; then
-			exit 1
-		fi
-	done
 	cd monero-lws || exit 1
-	# Temporary band-aid as newer commits don't seem to want to build
-	git checkout d8ee984b3c43babbefbb405ae7ebf75b57e85b0c # TODO remove when lws builds again
-	mkdir build
-	cd build || exit 1
+	git reset --hard
+	git pull
+	git checkout "$RELEASE"
+	submodule update --init --force
+	[ -d build ] && rm -rf build
+	mkdir build && cd $_ || exit 1
 	cmake -DMONERO_SOURCE_DIR=/home/nodo/monero -DMONERO_BUILD_DIR=/home/nodo/monero/build/release ..
-	showtext "Building VTNerd Monero-LWS"
 	make -j"$(nproc --ignore=2)" || exit 1
 	services-stop monero-lws
 	cp src/monero-lws* /home/nodo/bin/ || exit 1
@@ -57,6 +61,5 @@ showtext "Downloading VTNerd Monero-LWS"
 	putvar "versions.lws" "$RELEASE" || exit 1
 	putvar "versions.names.lws" "$_NAME"
 	cd || exit
-	rm -rf /home/nodo/monero-lws
 } 2>&1 | tee -a "$DEBUG_LOG"
 cd || exit 1

--- a/update-monero-lws.sh
+++ b/update-monero-lws.sh
@@ -26,7 +26,8 @@ _NAME="${RELNAME:0:8}"
 project="vtnerd"
 repo="monero-lws"
 githost="github.com"
-check_update_tag "${project}" "${repo}" "${githost}"
+commit_type="tag"  # [tag|release]
+check_update_tag "${project}" "${repo}" "${githost}" "${commit_type}"
 
 showtext "Building VTNerd Monero-LWS.."
 

--- a/update-monero.sh
+++ b/update-monero.sh
@@ -22,7 +22,8 @@ touch "$DEBUG_LOG"
 project="monero-project"
 repo="Monero"
 githost="github.com"
-check_update_tag "${project}" "${repo}" "${githost}"
+commit_type="release"  # [tag|release]
+check_update_tag "${project}" "${repo}" "${githost}" "${commit_type}"
 
 showtext "Building Monero..."
 

--- a/update-monero.sh
+++ b/update-monero.sh
@@ -9,35 +9,27 @@ fi
 
 #shellcheck source=home/nodo/common.sh
 . /home/nodo/common.sh
-
 cd /home/nodo || exit 1
 
 [ -d monero.retain ] && rm -rf monero.retain
 
 OLD_VERSION="${1:-$(getvar "versions.monero")}"
+OLD_TAG="${1:-$(getvar "versions.names.monero")}"
 #Error Log:
 touch "$DEBUG_LOG"
 
-RELNAME=$(get_release_commit_name "monero-project" "monero")
-RELEASE="$(printf '%s' "$RELNAME" | head -n1)"
-_NAME="$(printf '%s' "$RELNAME" | tail -n1)"
-
-if [ -z "$RELEASE" ] && [ -z "$FIRSTINSTALL" ]; then # Release somehow not set or empty
-	showtext "Failed to check for update for Monero"
-	exit 0
-fi
-
-if [ "$RELEASE" == "$OLD_VERSION" ]; then
-	showtext "No update for Monero"
-	exit 0
-fi
+#Check for updates
+project="monero-project"
+repo="Monero"
+githost="github.com"
+check_update_tag "${project}" "${repo}" "${githost}"
 
 showtext "Building Monero..."
 
 {
 	if [ ! -d monero ]; then
 		tries=0
-		until git clone --recursive https://github.com/monero-project/monero.git; do
+		until git clone --recursive https://"${githost}"/"${project}"/"${repo}" monero; do
 			sleep 1
 			tries=$((tries + 1))
 			if [ $tries -ge 5 ]; then
@@ -50,6 +42,7 @@ showtext "Building Monero..."
 	git pull
 	git checkout "$RELEASE"
 	git submodule update --init --force
+	# Cleanup build dir
 	[ -d build/release ] && rm -rf build/release
 	USE_DEVICE_TREZOR=OFF USE_SINGLE_BUILDDIR=1 make -j"$(nproc --ignore=2)" || exit 1
 	services-stop monerod

--- a/update-nodo.sh
+++ b/update-nodo.sh
@@ -19,7 +19,8 @@ touch "$DEBUG_LOG"
 project="moneronodo"
 repo="Nodo"
 githost="github.com"
-check_update_tag "${project}" "${repo}" "${githost}"
+commit_type="tag"  # [tag|release]
+check_update_tag "${project}" "${repo}" "${githost}" "${commit_type}"
 
 _cwd=/root/nodo
 

--- a/update-nodo.sh
+++ b/update-nodo.sh
@@ -10,24 +10,16 @@ fi
 #Create/ammend debug file for handling update errors:
 #shellcheck source=home/nodo/common.sh
 . /home/nodo/common.sh
-OLD_VERSION_NODO="${1:-$(getvar "versions.nodo")}"
+OLD_VERSION="${1:-$(getvar "versions.nodo")}"
+OLD_TAG="${1:-$(getvar "versions.names.nodo")}"
+#Error log
 touch "$DEBUG_LOG"
 
-RELNAME="$(get_tag_commit_name "moneronodo" "nodo")"
-
-RELEASE="$(printf '%s' "$RELNAME" | head -n1)"
-_NAME="$(printf '%s' "$RELNAME" | tail -n1)"
-_NAME="nodo-${_NAME}" # print as a string so the version is parsed properly
-
-if [ -z "$RELEASE" ]; then # Release somehow not set or empty
-	showtext "Failed to check for update for Nodo"
-	exit 0
-fi
-
-if [ "$RELEASE" == "$OLD_VERSION_NODO" ]; then
-	showtext "No update for Nodo"
-	exit 0
-fi
+#Check for updates
+project="moneronodo"
+repo="Nodo"
+githost="github.com"
+check_update_tag "${project}" "${repo}" "${githost}"
 
 _cwd=/root/nodo
 
@@ -37,7 +29,7 @@ if [ -d "${_cwd}" ]; then
 	cd nodo || exit 1
 	git pull
 else
-	until git clone https://github.com/moneronodo/nodo "${_cwd}"; do
+	until git clone https://"${githost}"/"${project}"/"${repo}" "${_cwd}"; do
 	sleep 1
 	tries=$((tries + 1))
 	if [ $tries -ge 5 ]; then

--- a/update-nodoui.sh
+++ b/update-nodoui.sh
@@ -20,7 +20,8 @@ touch "$DEBUG_LOG"
 project="moneronodo"
 repo="NodoUI"
 githost="github.com"
-check_update_tag "${project}" "${repo}" "${githost}"
+commit_type="tag"  # [tag|release]
+check_update_tag "${project}" "${repo}" "${githost}" "${commit_type}"
 
 showtext "
 ####################

--- a/update-nodoui.sh
+++ b/update-nodoui.sh
@@ -11,24 +11,16 @@ fi
 #shellcheck source=home/nodo/common.sh
 . /home/nodo/common.sh
 cd /home/nodo || exit 1
-OLD_VERSION_EUI="${1:-$(getvar "versions.nodoui")}"
-
-
-RELNAME=$(get_tag_commit_name "moneronodo" "nodoui")
-RELEASE="$(printf '%s' "$RELNAME" | head -n1)"
-_NAME="$(printf '%s' "$RELNAME" | tail -n1)"
-
-if [ -z "$RELEASE" ] && [ -z "$FIRSTINSTALL" ]; then # Release somehow not set or empty
-	showtext "Failed to check for update for Nodo UI"
-	exit 0
-fi
-
-if [ "$RELEASE" == "$OLD_VERSION_EUI" ]; then
-	showtext "No update for Nodo UI"
-	exit 0
-fi
-
+OLD_VERSION="${1:-$(getvar "versions.nodoui")}"
+OLD_TAG="${1:-$(getvar "versions.names.nodoui")}"
+#Error log
 touch "$DEBUG_LOG"
+
+#Check for updates
+project="moneronodo"
+repo="NodoUI"
+githost="github.com"
+check_update_tag "${project}" "${repo}" "${githost}"
 
 showtext "
 ####################
@@ -44,7 +36,7 @@ showtext "Downloading Nodo UI"
 		rm -rf /home/nodo/nodoui
 	}
 	trap remove INT HUP EXIT
-	git clone --recursive https://github.com/moneronodo/nodoui.git
+	git clone --recursive https://"${githost}"/"${project}"/"${repo}" nodoui
 	cd nodoui || exit 1
 	git reset --hard HEAD
 	git checkout "$RELEASE"

--- a/update-pay.sh
+++ b/update-pay.sh
@@ -11,32 +11,23 @@ fi
 . /home/nodo/common.sh
 cd /home/nodo || exit 1
 
-OLD_VERSION_EXP="${1:-$(getvar "versions.pay")}"
-
-RELNAME=$(gitlab_get_tag_commit_name "moneropay" "moneropay")
-RELEASE="$(printf '%s' "$RELNAME" | head -n1)"
-_NAME="$(printf '%s' "$RELNAME" | tail -n1)"
-
-#RELEASE=2d8478c
-
-if [ -z "$RELEASE" ] && [ -z "$FIRSTINSTALL" ]; then # Release somehow not set or empty
-	showtext "Failed to check for update for MoneroPay"
-	exit 0
-fi
-
-if [ "$RELEASE" == "$OLD_VERSION_EXP" ]; then
-	showtext "No update for MoneroPay"
-	exit 0
-fi
-
+OLD_VERSION="${1:-$(getvar "versions.pay")}"
+OLD_TAG="${1:-$(getvar "versions.names.pay")}"
+#Error log
 touch "$DEBUG_LOG"
+
+#Check for updates
+project="moneropay"
+repo="Moneropay"
+githost="gitlab.com"
+check_update_tag "${project}" "${repo}" "${githost}"
 
 {
 	tries=0
 	if [ -d moneropay ]; then
 		rm -rf /home/nodo/moneropay
 	fi
-	until git clone -b master https://gitlab.com/moneropay/moneropay; do
+	until git clone -b master https://"${githost}"/"${project}"/"${repo}" moneropay; do
 		sleep 1
 		tries=$((tries + 1))
 		if [ $tries -ge 5 ]; then

--- a/update-pay.sh
+++ b/update-pay.sh
@@ -20,7 +20,8 @@ touch "$DEBUG_LOG"
 project="moneropay"
 repo="Moneropay"
 githost="gitlab.com"
-check_update_tag "${project}" "${repo}" "${githost}"
+commit_type="tag"  # [tag|release]
+check_update_tag "${project}" "${repo}" "${githost}" "${commit_type}"
 
 {
 	tries=0

--- a/var/spool/cron/crontabs/root
+++ b/var/spool/cron/crontabs/root
@@ -1,5 +1,15 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-*/30 * * * * bash /root/nodo/update-all.sh
+# Check software updates
+@reboot sleep 60 && bash /root/nodo/update-all.sh | tee -a /root/update.log
+0 */12 * * * bash /root/nodo/update-all.sh | tee -a /root/update.log
+# Check banlist updates
 0 1 * * * bash /root/nodo/update-banlists.sh
+# Rotate logs
+15 1 1 * * mv /root/update.log /root/update-$(date --iso-8601).log
+15 1 1 * * mv /root/debug.log /root/debug-$(date --iso-8601).log
+# Compress logs
+30 1 1 * * tar czf /root/logs-$(date --iso-8601).tar.gz /root/*-*.log 
+45 1 1 * * rm /root/*-*.log
+# MoneroPay
 #0 * * * * bash /home/nodo/execScripts/monero-wallet-rpc-sweep.sh


### PR DESCRIPTION
1. Github returns non-empty / garbage responses sometimes, causing nodo to rebuild already up-to-date programs (like building monero over and over again).
Ive added a universal check/retry function, that will error out after 3 bad responses

2. All updaters use this same function
3. cron log rotate
4. cron @reboot update check
5. new, more verbose update.log
6. don't delete monero and lws clones. Still deleting the others

supercedes #27 