### PR TITLE
update: dont retain old ports

### DIFF
--- a/update-nodo.sh
+++ b/update-nodo.sh
@@ -65,12 +65,20 @@ showtext "User configuration saved"
 showtext "setup-nodo.sh..."
 bash "${_cwd}"/setup-nodo.sh
 
+# Restore config
 showtext "Merge config.json"
 if jq -s '.[0] * .[1] | {config: .config}' "${_v}"/config.json "${_v}"/config_retain.json > "${_v}"/config.merge.json; then
 	cp -f "${_v}"/config.merge.json "${_v}"/config.json
 else
 	cp -f "${_v}"/config_retain.json "${_v}"/config.json
 fi
+putvar 'zmq_pub' '18083'
+putvar 'tor_port' '18084'
+putvar 'i2p_port' '18085'
+putvar 'lws_port' '18086'
+putvar 'monero_port' '18080'
+putvar 'monero_public_port' '18081'
+putvar 'monero_rpc_port' '18089'
 
 chown nodo:nodo "${_v}"/config.json
 


### PR DESCRIPTION
Hotfix: old devices with old ports (ie, 18081 for i2p) will not startup due to double binding ports. this started as a result of fixing the merge direction

this fix just sets the ports to the correct values after merging configs