### PR TITLE
cron: remove update lockfile at system start

### DIFF
--- a/var/spool/cron/crontabs/root
+++ b/var/spool/cron/crontabs/root
@@ -1,6 +1,7 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Check software updates
+@reboot rm -f /home/nodo/variables/updatelock
 @reboot sleep 60 && bash /root/nodo/update-all.sh | tee -a /root/update.log
 0 */12 * * * bash /root/nodo/update-all.sh | tee -a /root/update.log
 # Check banlist updates


### PR DESCRIPTION
Its my assumption that if there is a power interruption during an update, that the lockfile becomes impossible to clear unless done manually (via tty/ssh).

this change will remove the lockfile at system start